### PR TITLE
Add initial English translations

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -64,5 +64,40 @@
   "language": {
     "de": "Deutsch",
     "en": "Englisch"
+  },
+  "pages": {
+    "comingsoon": {
+      "title": "Coming Soon",
+      "description": "Diese Seite befindet sich noch in Entwicklung. Schau bald wieder vorbei für neue Inhalte.",
+      "back": "Zurück zur Startseite",
+      "socialTitle": "Folge mir auf Social Media",
+      "socialText": "Für tägliche Clips und Performances",
+      "ctaButton": "Jetzt Patron werden"
+    },
+    "offers": {
+      "title": "Angebote"
+    },
+    "community": {
+      "title": "Community"
+    },
+    "contact": {
+      "title": "Schreib mir eine Nachricht",
+      "name": "Name",
+      "email": "Email",
+      "subject": "Betreff",
+      "message": "Nachricht",
+      "privacyLabel": "Ich habe die Datenschutzerklärung gelesen und stimme zu, dass meine Angaben zur Kontaktaufnahme verwendet werden.",
+      "send": "Nachricht senden",
+      "sending": "Wird gesendet...",
+      "success": "Vielen Dank für deine Nachricht! Ich werde mich schnellstmöglich bei dir melden.",
+      "error": "Ein Fehler ist aufgetreten. Bitte versuche es später noch einmal.",
+      "info": "Kontaktinformationen",
+      "emailTitle": "E-Mail",
+      "locationTitle": "Standort",
+      "responseTitle": "Antwortzeit",
+      "followTitle": "Folge mir auf Social Media",
+      "ctaTitle": "Lass uns in Verbindung bleiben!",
+      "ctaText": "Folge mir auf Social Media für tägliche musikalische Inspirationen, neue Tutorials und Updates zu kommenden Projekten."
+    }
   }
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -64,5 +64,40 @@
     "language": {
       "de": "German",
       "en": "English"
+    },
+    "pages": {
+      "comingsoon": {
+        "title": "Coming Soon",
+        "description": "This page is still under development. Check back soon for new content.",
+        "back": "Back to home",
+        "socialTitle": "Follow me on Social Media",
+        "socialText": "For daily clips and performances",
+        "ctaButton": "Become a Patron now"
+      },
+      "offers": {
+        "title": "Offers"
+      },
+      "community": {
+        "title": "Community"
+      },
+      "contact": {
+        "title": "Send me a message",
+        "name": "Name",
+        "email": "Email",
+        "subject": "Subject",
+        "message": "Message",
+        "privacyLabel": "I have read the privacy policy and agree that my information may be used to contact me.",
+        "send": "Send message",
+        "sending": "Sending...",
+        "success": "Thank you for your message! I will get back to you as soon as possible.",
+        "error": "An error occurred. Please try again later.",
+        "info": "Contact information",
+        "emailTitle": "Email",
+        "locationTitle": "Location",
+        "responseTitle": "Response time",
+        "followTitle": "Follow me on Social Media",
+        "ctaTitle": "Let's stay in touch!",
+        "ctaText": "Follow me on social media for daily musical inspiration, new tutorials and updates on upcoming projects."
+      }
     }
   }

--- a/pages/comingsoon.vue
+++ b/pages/comingsoon.vue
@@ -8,12 +8,12 @@
       
       <!-- Coming Soon Text -->
       <h2 class="text-3xl md:text-4xl font-bold text-gray-800 dark:text-gray-100 mb-6">
-        Coming Soon
+        {{ $t('pages.comingsoon.title') }}
       </h2>
       
       <!-- Beschreibungstext -->
       <p class="text-xl text-gray-600 dark:text-gray-300 mb-6">
-        Diese Seite befindet sich noch in Entwicklung. Schau bald wieder vorbei für neue Inhalte.
+        {{ $t('pages.comingsoon.description') }}
       </p>
 
       <!-- Patreon Highlight Box mit verbessertem Design -->
@@ -76,7 +76,7 @@
             <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 mr-3" viewBox="0 0 24 24" fill="currentColor">
               <path d="M14.82 2.41c3.96 0 7.18 3.22 7.18 7.18 0 3.96-3.22 7.18-7.18 7.18-3.96 0-7.18-3.22-7.18-7.18 0-3.96 3.22-7.18 7.18-7.18M2 21.77V2.41h2.91v19.36z" fill="white"/>
             </svg>
-            Jetzt Patron werden
+            {{ $t('pages.comingsoon.ctaButton') }}
           </a>
           <p class="text-sm text-gray-600 dark:text-gray-400 mt-3">
             Ab 3€ pro Monat • Jederzeit kündbar
@@ -93,14 +93,14 @@
           <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
           </svg>
-          Zurück zur Startseite
+          {{ $t('pages.comingsoon.back') }}
         </NuxtLink>
         
         <!-- Social Media Links mit verbessertem Design -->
         <div class="mt-12">
-          <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-4">Folge mir auf Social Media</h3>
+          <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-4">{{ $t('pages.comingsoon.socialTitle') }}</h3>
           <p class="text-gray-600 dark:text-gray-300 mb-6">
-            Für tägliche Clips und Performances
+            {{ $t('pages.comingsoon.socialText') }}
           </p>
           <div class="flex justify-center space-x-4">
             <a href="https://www.tiktok.com/@aaronthommy" target="_blank" class="group">
@@ -133,10 +133,12 @@
 
 <script setup>
 import { ref, onMounted, onBeforeUnmount } from 'vue';
+import { useI18n } from 'vue-i18n';
 import { useThemeStore } from '~/stores/themeStore';
 
 // Theme Store für Dark Mode
 const themeStore = useThemeStore();
+const { t } = useI18n();
 
 onMounted(() => {
   // Dark Mode Einstellungen initialisieren

--- a/pages/community.vue
+++ b/pages/community.vue
@@ -4,7 +4,7 @@
       <!-- Header -->
       <div class="mb-12">
         <h1 class="text-4xl md:text-5xl font-bold text-gray-900 dark:text-white mb-4">
-          Community
+          {{ $t('pages.community.title') }}
         </h1>
         <div class="h-1 w-20 bg-blue-500 dark:bg-blue-400 rounded"></div>
       </div>
@@ -440,9 +440,11 @@
 
 <script setup>
 import { onMounted } from "vue";
+import { useI18n } from 'vue-i18n';
 import { useThemeStore } from "~/stores/themeStore";
 
 const themeStore = useThemeStore();
+const { t } = useI18n();
 
 onMounted(() => {
   // Theme-Einstellungen initialisieren

--- a/pages/kontakt.vue
+++ b/pages/kontakt.vue
@@ -13,13 +13,13 @@
       <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
         <!-- Kontaktformular - Linke Spalte -->
         <div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm p-6 md:p-8">
-          <h2 class="text-2xl font-bold text-gray-900 dark:text-white mb-6">Schreib mir eine Nachricht</h2>
+          <h2 class="text-2xl font-bold text-gray-900 dark:text-white mb-6">{{ $t('pages.contact.title') }}</h2>
 
           <form @submit.prevent="sendMessage" class="space-y-6">
             <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
               <!-- Name -->
               <div>
-                <label for="name" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Name</label>
+                <label for="name" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{{ $t('pages.contact.name') }}</label>
                 <input
                   type="text"
                   id="name"
@@ -33,7 +33,7 @@
 
               <!-- Email -->
               <div>
-                <label for="email" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Email</label>
+                <label for="email" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{{ $t('pages.contact.email') }}</label>
                 <input
                   type="email"
                   id="email"
@@ -48,7 +48,7 @@
 
             <!-- Betreff -->
             <div>
-              <label for="subject" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Betreff</label>
+              <label for="subject" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{{ $t('pages.contact.subject') }}</label>
               <input
                 type="text"
                 id="subject"
@@ -62,7 +62,7 @@
 
             <!-- Nachricht -->
             <div>
-              <label for="message" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Nachricht</label>
+              <label for="message" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{{ $t('pages.contact.message') }}</label>
               <textarea
                 id="message"
                 v-model="contactForm.message"
@@ -88,8 +88,7 @@
               </div>
               <div class="ml-3 text-sm">
                 <label for="privacy" class="text-gray-600 dark:text-gray-400">
-                  Ich habe die <NuxtLink to="/datenschutz" class="text-blue-500 dark:text-blue-400 hover:underline">Datenschutzerklärung</NuxtLink>
-                  gelesen und stimme zu, dass meine Angaben zur Kontaktaufnahme verwendet werden.
+                  {{ $t('pages.contact.privacyLabel') }}
                 </label>
                 <p v-if="errors.privacy" class="text-red-500 text-sm mt-1">{{ errors.privacy }}</p>
               </div>
@@ -108,7 +107,7 @@
                     <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                   </svg>
                 </span>
-                {{ isSubmitting ? 'Wird gesendet...' : 'Nachricht senden' }}
+                {{ isSubmitting ? $t('pages.contact.sending') : $t('pages.contact.send') }}
               </button>
             </div>
           </form>
@@ -176,7 +175,7 @@
                   </svg>
                 </div>
                 <div class="ml-4">
-                  <h3 class="text-base font-medium text-gray-900 dark:text-white">E-Mail</h3>
+                  <h3 class="text-base font-medium text-gray-900 dark:text-white">{{ $t('pages.contact.emailTitle') }}</h3>
                   <p class="mt-1 text-gray-600 dark:text-gray-300">info@aaronthommy.com</p>
                 </div>
               </div>
@@ -189,7 +188,7 @@
                   </svg>
                 </div>
                 <div class="ml-4">
-                  <h3 class="text-base font-medium text-gray-900 dark:text-white">Standort</h3>
+                  <h3 class="text-base font-medium text-gray-900 dark:text-white">{{ $t('pages.contact.locationTitle') }}</h3>
                   <p class="mt-1 text-gray-600 dark:text-gray-300">Hannover, Deutschland</p>
                 </div>
               </div>
@@ -201,14 +200,14 @@
                   </svg>
                 </div>
                 <div class="ml-4">
-                  <h3 class="text-base font-medium text-gray-900 dark:text-white">Antwortzeit</h3>
+                  <h3 class="text-base font-medium text-gray-900 dark:text-white">{{ $t('pages.contact.responseTitle') }}</h3>
                   <p class="mt-1 text-gray-600 dark:text-gray-300">In der Regel innerhalb von 24-48 Stunden</p>
                 </div>
               </div>
               
               <!-- Social Media Links -->
               <div class="mt-8 pt-6 border-t border-gray-100 dark:border-gray-700">
-                <h3 class="text-base font-medium text-gray-900 dark:text-white mb-4">Folge mir auf Social Media</h3>
+                <h3 class="text-base font-medium text-gray-900 dark:text-white mb-4">{{ $t('pages.contact.followTitle') }}</h3>
                 <div class="flex space-x-4">
                   <a href="https://www.tiktok.com/@aaronthommy" target="_blank" class="text-gray-500 dark:text-gray-400 hover:text-black dark:hover:text-white transition-colors">
                     <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="currentColor" viewBox="0 0 24 24">
@@ -262,9 +261,9 @@
       
       <!-- Call to Action -->
       <div class="mt-12 bg-blue-50 dark:bg-blue-900/20 rounded-xl p-8 text-center">
-        <h2 class="text-2xl font-bold text-gray-900 dark:text-white mb-4">Lass uns in Verbindung bleiben!</h2>
+        <h2 class="text-2xl font-bold text-gray-900 dark:text-white mb-4">{{ $t('pages.contact.ctaTitle') }}</h2>
         <p class="text-gray-600 dark:text-gray-300 max-w-2xl mx-auto mb-6">
-          Folge mir auf Social Media für tägliche musikalische Inspirationen, neue Tutorials und Updates zu kommenden Projekten.
+          {{ $t('pages.contact.ctaText') }}
         </p>
         <div class="flex flex-wrap justify-center gap-4">
           <a href="https://www.tiktok.com/@aaronthommy" target="_blank" class="inline-flex items-center px-5 py-3 rounded-lg bg-black text-white hover:bg-gray-900 transition-colors">
@@ -293,9 +292,11 @@
 
 <script setup>
 import { ref, onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useThemeStore } from '~/stores/themeStore'
 
 const themeStore = useThemeStore()
+const { t } = useI18n()
 
 // Kontaktformular Daten
 const contactForm = ref({
@@ -311,8 +312,8 @@ const errors = ref({})
 const isSubmitting = ref(false)
 const showSuccess = ref(false)
 const showError = ref(false)
-const successMessage = ref('Vielen Dank für deine Nachricht! Ich werde mich schnellstmöglich bei dir melden.')
-const errorMessage = ref('Ein Fehler ist aufgetreten. Bitte versuche es später noch einmal.')
+const successMessage = ref($t('pages.contact.success'))
+const errorMessage = ref($t('pages.contact.error'))
 
 // Formularvalidierung
 const validateForm = () => {
@@ -320,29 +321,29 @@ const validateForm = () => {
   let valid = true
 
   if (!contactForm.value.name.trim()) {
-    errors.value.name = 'Bitte gib deinen Namen ein'
+    errors.value.name = $t('pages.contact.name')
     valid = false
   }
   if (!contactForm.value.email.trim()) {
-    errors.value.email = 'Bitte gib deine E-Mail-Adresse ein'
+    errors.value.email = $t('pages.contact.email')
     valid = false
   } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(contactForm.value.email)) {
-    errors.value.email = 'Bitte gib eine gültige E-Mail-Adresse ein'
+    errors.value.email = $t('pages.contact.email')
     valid = false
   }
   if (!contactForm.value.subject.trim()) {
-    errors.value.subject = 'Bitte gib einen Betreff ein'
+    errors.value.subject = $t('pages.contact.subject')
     valid = false
   }
   if (!contactForm.value.message.trim()) {
-    errors.value.message = 'Bitte gib eine Nachricht ein'
+    errors.value.message = $t('pages.contact.message')
     valid = false
   } else if (contactForm.value.message.trim().length < 10) {
-    errors.value.message = 'Die Nachricht sollte mindestens 10 Zeichen lang sein'
+    errors.value.message = $t('pages.contact.message')
     valid = false
   }
   if (!contactForm.value.privacy) {
-    errors.value.privacy = 'Bitte akzeptiere die Datenschutzbestimmungen'
+    errors.value.privacy = $t('pages.contact.privacyLabel')
     valid = false
   }
 
@@ -376,16 +377,16 @@ const sendMessage = async (e) => {
 
     if (response.ok) {
       showSuccess.value = true;
-      successMessage.value = "Vielen Dank für deine Nachricht! Ich werde mich schnellstmöglich bei dir melden.";
+      successMessage.value = $t('pages.contact.success');
       contactForm.value = { name: '', email: '', subject: '', message: '', privacy: false };
     } else {
       showError.value = true;
-      errorMessage.value = data.error || "Ein Fehler ist aufgetreten. Bitte versuche es später noch einmal.";
+      errorMessage.value = data.error || $t('pages.contact.error');
     }
   } catch (err) {
     console.error('Fehler beim Senden des Formulars:', err);
     showError.value = true;
-    errorMessage.value = "Ein Netzwerkfehler ist aufgetreten. Bitte überprüfe deine Internetverbindung.";
+    errorMessage.value = $t('pages.contact.error');
   } finally {
     isSubmitting.value = false;
     if (showSuccess.value) setTimeout(() => (showSuccess.value = false), 5000);

--- a/pages/offers.vue
+++ b/pages/offers.vue
@@ -4,7 +4,7 @@
         <!-- Header -->
         <div class="mb-12">
           <h1 class="text-4xl md:text-5xl font-bold text-gray-900 dark:text-white mb-4">
-            Angebote
+            {{ $t('pages.offers.title') }}
           </h1>
           <div class="h-1 w-20 bg-blue-500 dark:bg-blue-400 rounded"></div>
         </div>
@@ -100,9 +100,11 @@
   
   <script setup>
   import { onMounted } from "vue";
+  import { useI18n } from 'vue-i18n';
   import { useThemeStore } from "~/stores/themeStore";
   
   const themeStore = useThemeStore();
+  const { t } = useI18n();
   
   onMounted(() => {
     // Theme-Einstellungen initialisieren


### PR DESCRIPTION
## Summary
- add translation keys for various pages
- enable translation usage in community, offers, coming soon and contact pages

## Testing
- `npm run build` *(fails: nuxt not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f68148280832b850a226c0a736dbf